### PR TITLE
pad episode questions with newlines

### DIFF
--- a/episodes/27_publications.Rmd
+++ b/episodes/27_publications.Rmd
@@ -20,7 +20,8 @@ exercises: 10
 - What open source tools to use for applying data science practices in bioscience?
 - How to get your research work cited and invite more contributions to your project?
 - How to maintain history of contributions and contributors?
-- How should I mention and cite the software or data I am using
+- How should I mention and cite the software or data I am using?
+
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 

--- a/episodes/28_conclusion.Rmd
+++ b/episodes/28_conclusion.Rmd
@@ -12,7 +12,9 @@ exercises: 10
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::: questions
-- What are the most important take home message
+
+- What are the most important take home messages?
+
 ::::::::::::::::::::::::::::::::::::::::
 
 Feedback, questions


### PR DESCRIPTION
It seems that the `questions` divs need to have an empty line before and after the Markdown list of questions in order to be formatted correctly in the Schedule table on the Instructor View of the lesson homepage. This PR adds those empty lines in for two episodes.