### PR TITLE
Use spoilers instead of floating solutions

### DIFF
--- a/episodes/24_SettingUp.Rmd
+++ b/episodes/24_SettingUp.Rmd
@@ -43,7 +43,7 @@ exercises: 50
 
 What measures described in this session are meant to make research more reproducible, what measures are meant to facilitate team work. How does the different measures interact ?
 
-::::: solution
+::::: spoiler
 
 Making interaction measure is also making the research more reproducible. Indeed most of the reusability of the data and code can be best tested when several people interact on a project. Documenting for a current collaborator helps a lot to make sure documentation will be enough for new collaboratory coming in the project later on.
 :::::

--- a/episodes/24_SettingUp.Rmd
+++ b/episodes/24_SettingUp.Rmd
@@ -45,6 +45,8 @@ What measures described in this session are meant to make research more reproduc
 
 ::::: spoiler
 
+### Authors' summary
+
 Making interaction measure is also making the research more reproducible. Indeed most of the reusability of the data and code can be best tested when several people interact on a project. Documenting for a current collaborator helps a lot to make sure documentation will be enough for new collaboratory coming in the project later on.
 :::::
 

--- a/episodes/files/01-introduction.md
+++ b/episodes/files/01-introduction.md
@@ -13,6 +13,9 @@ What defines a research project ?
 What makes two projects in a lab different? 
 
 :::::: spoiler
+
+### Authors' summary
+
 The answer may vary with domain and lab culture, but the main components are very similar to what defines one research publication:
 
 - The vision or specific research question

--- a/episodes/files/01-introduction.md
+++ b/episodes/files/01-introduction.md
@@ -12,7 +12,7 @@ Reproducibility is introduced later in the course, while we expect participants 
 What defines a research project ? 
 What makes two projects in a lab different? 
 
-:::::: solution
+:::::: spoiler
 The answer may vary with domain and lab culture, but the main components are very similar to what defines one research publication:
 
 - The vision or specific research question

--- a/episodes/files/02-motivation.md
+++ b/episodes/files/02-motivation.md
@@ -170,7 +170,7 @@ Can you think of people who can help you in your research, directly in your lab 
 Would it help for them to have access to your data? How could they participate,
 and how can you give them credit?
 
-:::::::::::::::  solution
+:::::::::::::::  spoiler
 
 ## Needs from the future you
 

--- a/episodes/files/08-collaborativeworking.md
+++ b/episodes/files/08-collaborativeworking.md
@@ -62,7 +62,7 @@ You can read more about [Project Board in GitHub Documentation](https://docs.git
 
 *An example is Kanban for researcher project management. GitHub boards can be given any name.*
 
-:::::::::::::::  solution
+:::::::::::::::  spoiler
 
 ## Tutorial: Kanban Boards for Project Management (Click to view)
 

--- a/episodes/files/13-codereview.md
+++ b/episodes/files/13-codereview.md
@@ -149,7 +149,7 @@ This means code review is typically a fast, flexible, and interactive process.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-:::::::::::::::  solution
+:::::::::::::::  spoiler
 
 ## Github features to help with code review (Click to see)
 


### PR DESCRIPTION
This PR introduces [spoiler divs](https://carpentries.github.io/sandpaper-docs/episodes.html#expandable-spoiler-blocks) to the lesson, in place of "floating" solution blocks that are not associated with a challenge block. I think this will look better in the built lesson than the current solution blocks, which are positioned suboptimally when not adjoining a challenge.